### PR TITLE
Removed forward slash so that allowed origin was not a path

### DIFF
--- a/back-end/developerverse_project/settings.py
+++ b/back-end/developerverse_project/settings.py
@@ -145,7 +145,7 @@ STATIC_URL = '/static/'
 # Whitelisted CORS Domains
 # https://github.com/adamchainz/django-cors-headers#configuration
 CORS_ALLOWED_ORIGINS = [
-    "https://developerverse.netlify.app/",
+    "https://developerverse.netlify.app",
     "http://localhost:8080",
     "http://127.0.0.1:9000"
 ]


### PR DESCRIPTION
## Related Issues (include the `#`)


## Description of Changes Made
Per the description, Heroku would not allow the app to deploy unless the allowed origin was a domain and not a specific path

## Questions or Comments (optional)

