### PR TITLE
Deleted depreciated import link from index.html

### DIFF
--- a/front-end/public/index.html
+++ b/front-end/public/index.html
@@ -3,7 +3,6 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link rel="stylesheet" href="../css/mystyles.css" />
     <meta
       name="description"
       content="Web site created using create-react-app"


### PR DESCRIPTION
## Related Issues (include the `#`)


## Description of Changes Made
The Bulma CSS package added a link to index.html.  Now that Bulma has been removed, we no longer need this import link as the file does not exist.  This change does not affect anything else.

## Questions or Comments (optional)

